### PR TITLE
Update dependency version to patch a security vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "hammerjs": "^2.0.8",
     "knockout": "^3.4.0",
     "knockout-es5": "^0.4.4",
-    "markdown-it": "^7.0.0",
+    "markdown-it": "^12.3.2",
     "markdown-it-sanitizer": "^0.4.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Proposing to update "markdown-it" dependency to version 12.3.2 to patch a known security vulnerability [CVE-2022-21670](https://nvd.nist.gov/vuln/detail/CVE-2022-21670)

Thank you for your consideration!